### PR TITLE
Migrate runtime expressions and OAS Version

### DIFF
--- a/amati/fields/__init__.py
+++ b/amati/fields/__init__.py
@@ -12,4 +12,4 @@ from amati.fields.http_status_codes import HTTPStatusCode
 from amati.fields.iso9110 import HTTPAuthenticationScheme
 from amati.fields.media import MediaType
 from amati.fields.spdx_licences import SPDXURL, SPDXIdentifier
-from amati.fields.uri import URI
+from amati.fields.uri import URI, URIType, URIWithVariables

--- a/amati/validators/generic.py
+++ b/amati/validators/generic.py
@@ -44,7 +44,8 @@ class GenericObject(LogMixin, BaseModel):
         for field in data:
             if (
                 field
-                not in self.model_fields  # pylint: disable=unsupported-membership-test
+                # FIXME: https://github.com/ben-alexander/amati/issues/21
+                not in self.model_fields  # pylint: disable=unsupported-membership-test # type: ignore
             ):
                 message = f"{field} is not a valid field for {self.__repr_name__()}."
                 self.log(

--- a/amati/validators/oas311.py
+++ b/amati/validators/oas311.py
@@ -360,7 +360,7 @@ class ResponsesObject(GenericObject):
     @model_validator(mode="before")
     @classmethod
     def validate_all_fields(cls, data: dict[str, Any]) -> _ResponsesObjectReturnType:
-        """ 
+        """
         Validates the responses object.
         """
 

--- a/tests/fields/test_oas.py
+++ b/tests/fields/test_oas.py
@@ -3,39 +3,22 @@ Tests amati/fields/oas.py
 """
 
 import pytest
-from abnf.parser import ParseError
 from hypothesis import given
 from hypothesis import strategies as st
 
+from amati import AmatiValueError
 from amati.fields.oas import OPENAPI_VERSIONS, OpenAPI, RuntimeExpression
-from amati.logging import LogMixin
-from amati.validators.generic import GenericObject
-
-
-class OpenAPIModel(GenericObject):
-    value: OpenAPI
-
-
-class RuntimExpressionModel(GenericObject):
-    value: RuntimeExpression
 
 
 @given(st.text().filter(lambda x: x not in OPENAPI_VERSIONS))
 def test_invalid_openapi_version(value: str):
-    with LogMixin.context():
-        OpenAPIModel(value=value)
-        assert LogMixin.logs
-        assert LogMixin.logs[0].message is not None
-        assert LogMixin.logs[0].type == ValueError
-        assert LogMixin.logs[0].reference is not None
+    with pytest.raises(AmatiValueError):
+        OpenAPI(value)
 
 
 @given(st.sampled_from(OPENAPI_VERSIONS))
 def test_valid_openapi_version(value: str):
-    with LogMixin.context():
-        model = OpenAPIModel(value=value)
-        assert model.value == value
-        assert not LogMixin.logs
+    OpenAPI(value)
 
 
 def test_valid_runtime_expression():
@@ -78,7 +61,7 @@ def test_valid_runtime_expression():
     ]
 
     for expression in expressions:
-        assert RuntimExpressionModel(value=expression).value == expression
+        assert RuntimeExpression(expression) == expression
 
 
 def test_invalid_runtime_expression():
@@ -116,6 +99,5 @@ def test_invalid_runtime_expression():
     ]
 
     for expression in expressions:
-        print(expression)
-        with pytest.raises(ParseError):
-            RuntimExpressionModel(value=expression)
+        with pytest.raises(AmatiValueError):
+            RuntimeExpression(expression)


### PR DESCRIPTION
- Migrate the runtime expressions and OAS version data types to strings as described in https://github.com/ben-alexander/amati/pull/16.

- Add the `Response` and `Responses` objects

- Temporarily supress Pyright raising a warning about future deprecation on the use of `self.model_fields()` until https://github.com/ben-alexander/amati/issues/21 is completed.